### PR TITLE
Changes in `MessageDialog` and `RichWindow`

### DIFF
--- a/MSB.UI-WPF/Assets/Styles/Styles.xaml
+++ b/MSB.UI-WPF/Assets/Styles/Styles.xaml
@@ -1103,18 +1103,4 @@
     <!--Default 'System.Windows.Controls.ComboBox' style...-->
     <Style TargetType="ComboBox" BasedOn="{StaticResource BaseComboBoxStyle}"/>
 
-    <!--
-    ***************************************************************
-    **********     SYSTEM.WINDOWS.CONTROLS.PAGE
-    ***************************************************************
-    -->
-
-    <Style x:Key="BasePageStyle" TargetType="Page">
-        <Setter Property="Background" Value="{DynamicResource PageBackground}"/>
-        <Setter Property="Foreground" Value="{DynamicResource PageForeground}"/>
-    </Style>
-
-    <!--Default 'System.Windows.Controls.Page' style...-->
-    <Style TargetType="Page" BasedOn="{StaticResource BasePageStyle}"/>
-
 </ResourceDictionary>

--- a/MSB.UI-WPF/MSB.UI-WPF.csproj
+++ b/MSB.UI-WPF/MSB.UI-WPF.csproj
@@ -20,7 +20,7 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>2.1.1</Version>
+		<Version>2.0.0</Version>
 		<PackageIcon>Icon.png</PackageIcon>
 		<PackageTags>Toolkit; Controls; .NET; WPF</PackageTags>
 		<Description>MSB.UI (Windows Presentation) is a .NET library designed to provide WPF solutions.</Description>

--- a/MSB.UI-WPF/Themes/Generic.xaml
+++ b/MSB.UI-WPF/Themes/Generic.xaml
@@ -289,7 +289,7 @@
     ***************************************************************
     -->
 
-    <Style TargetType="msui:RichWindow">
+    <Style TargetType="msui:AeroWindow">
         <Setter Property="Background" Value="{DynamicResource WindowBackground}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource WindowBorderBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource WindowForeground}"/>
@@ -302,7 +302,7 @@
         <Setter Property="Focusable" Value="False"/>
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="msui:RichWindow">
+                <ControlTemplate TargetType="msui:AeroWindow">
                     <Border x:Name="BorderRoot" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}" TextElement.Foreground="{TemplateBinding Foreground}">
                         <Grid >
@@ -422,9 +422,9 @@
                             <Grid Grid.Row="1" x:Name="PART_Content" TextElement.Foreground="{TemplateBinding Foreground}">
                                 <StackPanel Margin="20, 10">
                                     <TextBlock x:Name="CaptionTextBlock" TextTrimming="CharacterEllipsis" FontSize="18" FontWeight="SemiBold"
-                                               Text="{Binding Caption}"/>
+                                               Text="{Binding Title}"/>
                                     <TextBlock x:Name="ContentTextBlock" TextWrapping="Wrap" FontSize="14" Margin="0, 10, 0, 10"
-                                               Text="{Binding Content}"/>
+                                               Text="{Binding Message}"/>
                                 </StackPanel>
                                 <ContentPresenter x:Name="CustomContentPresenter" Content="{Binding CustomContent}"/>
                             </Grid>
@@ -445,10 +445,10 @@
                         <Trigger Property="IsActive" Value="False">
                             <Setter Property="BorderBrush" Value="{DynamicResource WindowChromeBorderBrushInactive}"/>
                         </Trigger>
-                        <DataTrigger Binding="{Binding Caption}" Value="">
+                        <DataTrigger Binding="{Binding Title}" Value="">
                             <Setter TargetName="CaptionTextBlock" Property="Visibility" Value="Collapsed"/>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding Content}" Value="">
+                        <DataTrigger Binding="{Binding Message}" Value="">
                             <Setter TargetName="ContentTextBlock" Property="Visibility" Value="Collapsed"/>
                         </DataTrigger>
                         <DataTrigger Binding="{Binding CustomContent}" Value="{x:Null}">
@@ -490,9 +490,11 @@
         <Setter Property="Background" Value="{DynamicResource FlyoutBackground}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource FlyoutBorderBrush}"/>
         <Setter Property="Foreground" Value="{DynamicResource FlyoutForeground}"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="MinHeight" Value="150"/>
-        <Setter Property="MinWidth" Value="150"/>
+        <Setter Property="MinHeight" Value="100"/>
+        <Setter Property="MinWidth" Value="100"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="msuc:Flyout">
@@ -540,7 +542,7 @@
                                 <DropShadowEffect Color="{DynamicResource DropShadowColor}" ShadowDepth="5" BlurRadius="5" Direction="270" Opacity="0.25"/>
                             </Border.Effect>
                         </Border>
-                        <ContentPresenter Content="{TemplateBinding Content}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                        <ContentPresenter Content="{TemplateBinding Content}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="10"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                     </Grid>
                 </ControlTemplate>

--- a/MSB.UI-WPF/UI/AeroWindow.cs
+++ b/MSB.UI-WPF/UI/AeroWindow.cs
@@ -11,14 +11,14 @@ namespace MSB.UI
     /// Represents a window with new functions, such as the ability to hide the icon,
     /// the title or cover the title bar with its contents.
     /// </summary>
-    public class RichWindow : Window
+    public class AeroWindow : Window
     {
         /// <summary>
-        /// Initializes a new instance of the 'RichWindow' class.
+        /// Initializes a new instance of the 'AeroWindow' class.
         /// </summary>
-        public RichWindow()
+        public AeroWindow()
         {
-            this.DefaultStyleKey = typeof(RichWindow);
+            this.DefaultStyleKey = typeof(AeroWindow);
         }
 
         #region Properties
@@ -80,31 +80,31 @@ namespace MSB.UI
         /// Identifies the ExtendViewIntoTitleBar dependency property.
         /// </summary>
         public static readonly DependencyProperty ExtendViewIntoTitleBarProperty =
-                DependencyProperty.Register(nameof(ExtendViewIntoTitleBar), typeof(bool), typeof(RichWindow), new PropertyMetadata(false));
+                DependencyProperty.Register(nameof(ExtendViewIntoTitleBar), typeof(bool), typeof(AeroWindow), new PropertyMetadata(false));
 
         /// <summary>
         /// Identifies the IsIconVisible dependency property.
         /// </summary>
         public static readonly DependencyProperty IsIconVisibleProperty =
-                DependencyProperty.Register(nameof(IsIconVisible), typeof(bool), typeof(RichWindow), new PropertyMetadata(true));
+                DependencyProperty.Register(nameof(IsIconVisible), typeof(bool), typeof(AeroWindow), new PropertyMetadata(true));
 
         /// <summary>
         /// Identifies the IsTitleVisible dependency property.
         /// </summary>
         public static readonly DependencyProperty IsTitleVisibleProperty =
-                DependencyProperty.Register(nameof(IsTitleVisible), typeof(bool), typeof(RichWindow), new PropertyMetadata(true));
+                DependencyProperty.Register(nameof(IsTitleVisible), typeof(bool), typeof(AeroWindow), new PropertyMetadata(true));
 
         /// <summary>
         /// Identifies the FlyoutContent dependency property.
         /// </summary>
         public static readonly DependencyProperty FlyoutProperty =
-                DependencyProperty.Register(nameof(Flyout), typeof(Flyout), typeof(RichWindow), new PropertyMetadata(null, FlyoutChanged_Callback));
+                DependencyProperty.Register(nameof(Flyout), typeof(Flyout), typeof(AeroWindow), new PropertyMetadata(null, FlyoutChanged_Callback));
 
         /// <summary>
         /// Identifies the IsFlyoutOpen dependency property.
         /// </summary>
         public static readonly DependencyProperty IsFlyoutOpenProperty =
-                DependencyProperty.Register(nameof(IsFlyoutOpen), typeof(bool), typeof(RichWindow), new PropertyMetadata(false));
+                DependencyProperty.Register(nameof(IsFlyoutOpen), typeof(bool), typeof(AeroWindow), new PropertyMetadata(false));
 
         #endregion
 
@@ -112,7 +112,7 @@ namespace MSB.UI
 
         static void FlyoutChanged_Callback(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (e.OldValue != e.NewValue && d is RichWindow window)
+            if (e.OldValue != e.NewValue && d is AeroWindow window)
             {
                 if (e.NewValue is not Flyout flyout)
                     return;
@@ -195,7 +195,10 @@ namespace MSB.UI
 
         private void LightDismissLayer_Pressed(object sender, MouseButtonEventArgs e)
         {
-            this.Flyout?.SetCurrentValue(Flyout.IsOpenProperty, false);
+            if (this.Flyout is null)
+                return;
+
+            this.Flyout.IsOpen = false;
         }
 
         private void OnFlyoutClosed(object sender, EventArgs args)

--- a/MSB.UI-WPF/UI/Controls/FontIcon.cs
+++ b/MSB.UI-WPF/UI/Controls/FontIcon.cs
@@ -59,7 +59,7 @@ namespace MSB.UI.Controls
         /// Identifies the FontSize dependency property.
         /// </summary>
         public static readonly DependencyProperty FontSizeProperty =
-                TextElement.ForegroundProperty.AddOwner(typeof(FontIcon));
+                TextElement.FontSizeProperty.AddOwner(typeof(FontIcon));
 
         /// <summary>
         /// Identifies the Glyph dependency property.

--- a/MSB.UI-WPF/UI/Controls/MessageDialog.cs
+++ b/MSB.UI-WPF/UI/Controls/MessageDialog.cs
@@ -18,21 +18,21 @@ namespace MSB.UI.Controls
         #region Properties
 
         /// <summary>
-        /// Gets or sets the text to display.
+        /// Gets or sets the title bar caption to display.
         /// </summary>
-        public string Content
+        public string Title
         {
-            get => (string)GetValue(ContentProperty);
-            set => SetValue(ContentProperty, value);
+            get => (string)GetValue(TitleProperty);
+            set => SetValue(TitleProperty, value);
         }
 
         /// <summary>
-        /// Gets or sets the title bar caption to display.
+        /// Gets or sets the text to display.
         /// </summary>
-        public string Caption
+        public string Message
         {
-            get => (string)GetValue(CaptionProperty);
-            set => SetValue(CaptionProperty, value);
+            get => (string)GetValue(MessageProperty);
+            set => SetValue(MessageProperty, value);
         }
 
         /// <summary>
@@ -58,16 +58,16 @@ namespace MSB.UI.Controls
         #region Dependency properties
 
         /// <summary>
-        /// Identifies the Content dependency property.
-        /// </summary>
-        public static readonly DependencyProperty ContentProperty =
-                DependencyProperty.Register(nameof(Content), typeof(string), typeof(MessageDialog), new PropertyMetadata(string.Empty));
-
-        /// <summary>
         /// Identifies the Caption dependency property.
         /// </summary>
-        public static readonly DependencyProperty CaptionProperty =
-                DependencyProperty.Register(nameof(Caption), typeof(string), typeof(MessageDialog), new PropertyMetadata(string.Empty));
+        public static readonly DependencyProperty TitleProperty =
+                DependencyProperty.Register(nameof(Title), typeof(string), typeof(MessageDialog), new PropertyMetadata(string.Empty));
+
+        /// <summary>
+        /// Identifies the Content dependency property.
+        /// </summary>
+        public static readonly DependencyProperty MessageProperty =
+                DependencyProperty.Register(nameof(Message), typeof(string), typeof(MessageDialog), new PropertyMetadata(string.Empty));
 
         /// <summary>
         /// Identifies the CustomContent dependency property.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,94 @@
-# MSB.UI (Windows Presentation)
+# MSB.UI-WPF
+MSB.UI-WPF is a UI library for Windows Presentation Foundation (WPF) applications. It provides a variety of controls and widgets that can be used to create complex and engaging user interfaces.
+
+## Features
+MSB.UI-WPF includes a variety of features, including:
+
+A variety of controls and widgets, such as text boxes, lists, dialog boxes, and more
+Support for styles and themes
+Support for accessibility
+## Installation
+MSB.UI-WPF can be installed from NuGet. To install it, open the Visual Studio Package Manager and search for "MSB.UI-WPF". Click the "Install" button to install the library.
+
+## Usage
+MSB.UI-WPF can be used in the same way as any other WPF UI library. To use the library, add it as a reference to your project. Then, you can begin using the controls and widgets from the library in your user interface.
+
+In your `App.xaml`...
+
+```xaml
+<Application x:Class="MyProject.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+        <ResourceDictionary >
+            <ResourceDictionary.MergedDictionaries>
+                <!--MSB.UI-WPF assets-->
+                <ResourceDictionary Source="/MSB.UI-WPF;component/Assets/Fonts/Fonts.xaml"/>
+                <ResourceDictionary Source="/MSB.UI-WPF;component/Assets/Styles/Styles.xaml"/>
+                <ResourceDictionary Source="/MSB.UI-WPF;component/Assets/Themes/Light.Green.xaml"/>
+                
+                <!--your assets-->
+                ...
+            </ResourceDictionary.MergedDictionaries>
+
+            <!--other assets-->
+            ...
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>
+```
+
+In your `MainPage.xaml`...
+
+```xaml
+<Page x:Class="MyProject.Views.MainPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:msb="http://ui.msb-studios.com/winfx/xaml" <!--add this-->
+      mc:Ignorable="d"
+      
+      d:DesignHeight="550" d:DesignWidth="600">
+
+    <Grid Background="{DynamicResource PageBackground}">
+        <msb:NavigationView IsActingAsTitleBar="True">
+            <!--add your content here-->
+        </msb:NavigationView>
+    </Grid>
+</Page>
+```
+
+## Release Notes
+
+### [Version 2.0.0] - 2023-07-20
+
+#### Added
+
+- Added the `MenuItemsVisibility` and `FooterItemsVisibility` property in the `NavigationViewTemplateSettings` type. These new properties allow the `NavigationViewList` in `NavigationView` to be hidden or shown depending on whether they have items or not.
+- Introduced `ApplicationTheme` and `ApplicationAccentColor` enums to make it easier for users to manage the theme and accent color of the application, as long as 'MSB.UI' resources are used.
+
+#### Changed
+
+- The `ModernWindow` control has been renamed to `AeroWindow`.
+- `Flyout` is now included inside `AeroWindow`, however its default value is `null`. Create a new instance and use it according to your needs.
+- Added the `CustomContentPlacement` property in the `NavigationView` type.
+
+#### Removed
+
+- The values `Top` and `Left` in the `LabelPosition` enum of the `AppBarButton` type were removed and its template was updated.
+
+#### Fixed
+
+- Fixed a bug that caused the brush in the `PathIcon` type to not update when the visual parent changed its `Foreground` property.
+
+#### Notes
+
+- Almost all the brushes resources have been renamed, many others were removed and some others added, for more details click [here](https://github.com/MSB-Studios/MSB.UI-Windows-Presentation/blob/main/MSB.UI-WPF/Assets/Themes/Light.Pink.xaml) to know the resources included in this version.
+- The `MessageDialog` type has also received changes, its `Caption` property is now `Title` and `Content` changed to `Message`.
+
+## Contributions
+MSB.UI-WPF is an open source project. If you would like to contribute to the project, you can submit your changes through the MSB.UI-WPF [GitHub repository](https://github.com/MSB-Studios/MSB.UI-Windows-Presentation).
+
+## Thank you
+Thank you for using MSB.UI-WPF!


### PR DESCRIPTION
- Properties of type `MessageDialog` renamed.
- `RichWindow` is now `AeroWindow` and its template has been updated.

README.md file modified.